### PR TITLE
feat: apply fnm completion on zsh

### DIFF
--- a/fnm.plugin.zsh
+++ b/fnm.plugin.zsh
@@ -4,4 +4,5 @@
 eval "$(fnm env --use-on-cd)"
 
 # Add fnm completions
-fnm completions --shell zsh
+fnm_completion="$(dirname "$(readlink -f "$0")")/_fnm"
+fnm completions --shell zsh > "$fnm_completion"

--- a/fnm.plugin.zsh
+++ b/fnm.plugin.zsh
@@ -5,4 +5,5 @@ eval "$(fnm env --use-on-cd)"
 
 # Add fnm completions
 fnm_completion="$(dirname "$(readlink -f "$0")")/_fnm"
+fpath=($fnm_completion $fpath)
 fnm completions --shell zsh > "$fnm_completion"


### PR DESCRIPTION
I install the plugin with antigen, but it looks like the  `fnm completions --shell zsh` command only print the script for me, so I referenced this issue and modified it.
[https://github.com/Schniz/fnm/issues/171](url)
antigen will automatically add fpath and compinit, so I didn't handle them here.